### PR TITLE
[TASK] Align with new TYPO3 documentation standards (follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+[![Latest Stable Version](https://poser.pugx.org/friendsoftypo3/crowdin/v/stable.svg)](https://extensions.typo3.org/extension/friendsoftypo3/crowdin/)
+[![TYPO3 10](https://img.shields.io/badge/TYPO3-10-orange.svg?style=flat-square)](https://get.typo3.org/version/10)
+[![TYPO3 9](https://img.shields.io/badge/TYPO3-9-orange.svg?style=flat-square)](https://get.typo3.org/version/9)
+[![Total Downloads](https://poser.pugx.org/friendsoftypo3/crowdin/d/total.svg)](https://packagist.org/packages/friendsoftypo3/crowdin)
+[![Monthly Downloads](https://poser.pugx.org/friendsoftypo3/crowdin/d/monthly)](https://packagist.org/packages/friendsoftypo3/crowdin)
+
 # TYPO3 extension `crowdin`
 
 This extensions enables the **In-Context Localization** feature of Crowdin for

--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,11 @@
 		"localization",
 		"translation"
 	],
-	"homepage": "https://github.com/FriendsOfTYPO3/crowdin",
+	"homepage": "https://extensions.typo3.org/extension/crowdin/",
 	"support": {
-		"issues": "https://github.com/FriendsOfTYPO3/crowdin/issues"
+		"issues": "https://github.com/FriendsOfTYPO3/crowdin/issues",
+		"source": "https://github.com/FriendsOfTYPO3/crowdin",
+		"docs": "https://docs.typo3.org/p/friendsoftypo3/crowdin/main/en-us/"
 	},
 	"authors": [
 		{


### PR DESCRIPTION
Added two new commits regarding badges in README and additional sources (TER, repository and docs.typo3.org) in composer.json.

In addition, what is missing
(1) The "Packagist" button on the [TER page](https://extensions.typo3.org/extension/crowdin/), which seems to be caused by the empty "Composer name of extension" field in the TER extension edit form.
(2) Registering this documentation for rendering and publishing at docs.typo3.org with the [webhook](https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocForExtension/Webhook.html#github).
(3) Adding the new manual URL https://docs.typo3.org/p/friendsoftypo3/crowdin/main/en-us/ to the TER extension page configuration.

Relates: TYPO3-Documentation/T3DocTeam#185