### PR TITLE
[TASK] Move vendor and public folder into dedicated .Build folder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,16 @@
 			"dev-main": "3.0.x-dev"
 		},
 		"typo3/cms": {
+			"web-dir": ".Build/public",
 			"extension-key": "crowdin"
 		}
+	},
+	"config": {
+		"allow-plugins": {
+			"typo3/cms-composer-installers": true,
+			"typo3/class-alias-loader": true
+		},
+		"bin-dir": ".Build/bin",
+		"vendor-dir": ".Build/vendor"
 	}
 }


### PR DESCRIPTION
To declutter the main directory for development, the `vendor/` and `public/` folders are moved to a `.Build/` folder. This is good practise, for example, used in EXT:news.

The `vendor/bin/` folder has also been moved to `.Build/bin/` to make the access easier (would be `.Build/vendor/bin` otherwise).

Additionally, two plugins are allowed as required by Composer 2.