### PR TITLE
[BUGFIX] Fix "undefined array key items"

### DIFF
--- a/Classes/Backend/ToolbarItems/CrowdinToolbarItem.php
+++ b/Classes/Backend/ToolbarItems/CrowdinToolbarItem.php
@@ -132,6 +132,8 @@ class CrowdinToolbarItem implements ToolbarItemInterface
                 'itemFormElValue' => $enabled ? 1 : 0,
                 'fieldConf' => [
                     'config' => [
+                        // "items" is needed for TYPO3 v11
+                        'items' => [],
                         'readOnly' => false,
                     ],
                 ],


### PR DESCRIPTION
After installing EXT:crowdin in TYPO3 v11 the backend is not usable because of an error:

```
PHP Warning: Undefined array key "items" in typo3/sysext/backend/Classes/Form/Element/CheckboxToggleElement.php line 76

in crowdin/Classes/Backend/ToolbarItems/CrowdinToolbarItem.php line 160 
in crowdin/Classes/Backend/ToolbarItems/CrowdinToolbarItem.php line 99
...
```

In TYPO3 v12 and v13 this error does not occur, the problem seems to be mitigated there.