### PR TITLE
[TASK] Use dependency injection in commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,93 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    name: Build PHP/TYPO3
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php-versions: '8.1'
+            typo3-versions: '^11'
+          - php-versions: '8.1'
+            typo3-versions: '^12'
+          - php-versions: '8.2'
+            typo3-versions: '^11'
+          - php-versions: '8.2'
+            typo3-versions: '^12'
+          - php-versions: '8.2'
+            typo3-versions: '^13'
+          - php-versions: '8.3'
+            typo3-versions: '^11'
+          - php-versions: '8.3'
+            typo3-versions: '^12'
+          - php-versions: '8.3'
+            typo3-versions: '^13'
+          - php-versions: '8.4'
+            typo3-versions: '^12'
+          - php-versions: '8.4'
+            typo3-versions: '^13'
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+      - name: Setup PHP version
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: mbstring
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - name: Cache composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Install composer dependencies
+        run: |
+          composer require typo3/cms-core=${{ matrix.typo3-versions }} --no-progress --prefer-dist --optimize-autoloader
+      - name: Run PHP linter
+        run: |
+          find . -type f -name '*.php' ! -path "./.Build/*" -print0 | xargs -0 -n1 -P4 php -l -n | (! grep -v "No syntax errors detected" )
+      - name: Run unit tests
+        run: |
+          .Build/bin/phpunit -c Tests/phpunit.xml.dist
+  code-quality:
+    name: Code Quality
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+      - name: Setup PHP version
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.2
+          extensions: mbstring
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - name: Cache composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Install composer dependencies
+        run: |
+          composer --version
+          composer update --no-progress --prefer-dist --optimize-autoloader
+      - name: Verify PSR-4 namespace correctness
+        run: |
+          composer dumpautoload --optimize --strict-psr

--- a/Classes/Command/DisableCommand.php
+++ b/Classes/Command/DisableCommand.php
@@ -9,15 +9,21 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-class DisableCommand extends Command
+final class DisableCommand extends Command
 {
+    public function __construct(
+        private readonly Setup $setup,
+    ) {
+        parent::__construct();
+    }
+
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        GeneralUtility::makeInstance(Setup::class)->disable();
+        $this->setup->disable();
         $io = new SymfonyStyle($input, $output);
         $io->success('Crowdin disabled');
+
         return Command::SUCCESS;
     }
 }

--- a/Classes/Command/EnableCommand.php
+++ b/Classes/Command/EnableCommand.php
@@ -9,15 +9,21 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-class EnableCommand extends Command
+final class EnableCommand extends Command
 {
+    public function __construct(
+        private readonly Setup $setup,
+    ) {
+        parent::__construct();
+    }
+
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        GeneralUtility::makeInstance(Setup::class)->enable();
+        $this->setup->enable();
         $io = new SymfonyStyle($input, $output);
         $io->success('Crowdin enabled');
+
         return Command::SUCCESS;
     }
 }

--- a/Tests/Unit/Command/DisableCommandTest.php
+++ b/Tests/Unit/Command/DisableCommandTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace FriendsOfTYPO3\Crowdin\Tests\Unit\Command;
+
+use FriendsOfTYPO3\Crowdin\Command\DisableCommand;
+use FriendsOfTYPO3\Crowdin\Setup;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[CoversClass(DisableCommand::class)]
+final class DisableCommandTest extends TestCase
+{
+    #[Test]
+    public function setUp(): void
+    {
+        $setupMock = self::createMock(Setup::class);
+        $setupMock
+            ->expects(self::once())
+            ->method('disable');
+
+        $command = new DisableCommand($setupMock);
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute([]);
+
+        self::assertSame(0, $commandTester->getStatusCode());
+        self::assertStringContainsString('[OK] Crowdin disabled', $commandTester->getDisplay());
+    }
+}

--- a/Tests/Unit/Command/EnableCommandTest.php
+++ b/Tests/Unit/Command/EnableCommandTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace FriendsOfTYPO3\Crowdin\Tests\Unit\Command;
+
+use FriendsOfTYPO3\Crowdin\Command\EnableCommand;
+use FriendsOfTYPO3\Crowdin\Setup;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[CoversClass(EnableCommand::class)]
+final class EnableCommandTest extends TestCase
+{
+    #[Test]
+    public function setUp(): void
+    {
+        $setupMock = self::createMock(Setup::class);
+        $setupMock
+            ->expects(self::once())
+            ->method('enable');
+
+        $command = new EnableCommand($setupMock);
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute([]);
+
+        self::assertSame(0, $commandTester->getStatusCode());
+        self::assertStringContainsString('[OK] Crowdin enabled', $commandTester->getDisplay());
+    }
+}

--- a/Tests/phpunit.xml.dist
+++ b/Tests/phpunit.xml.dist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="../.Build/vendor/phpunit/phpunit/phpunit.xsd"
+        bootstrap="../.Build/vendor/autoload.php"
+        cacheResult="false"
+        displayDetailsOnTestsThatTriggerDeprecations="true"
+        displayDetailsOnTestsThatTriggerErrors="true"
+        displayDetailsOnTestsThatTriggerNotices="true"
+        displayDetailsOnTestsThatTriggerWarnings="true"
+        executionOrder="random"
+>
+    <coverage/>
+    <testsuites>
+        <testsuite name="Unit tests">
+            <directory>Unit/</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>../Classes/</directory>
+        </include>
+    </source>
+</phpunit>

--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,17 @@
 		"php": ">= 8.1.0, <= 8.4.99",
 		"typo3/cms-core": "^11 || ^12 || ^13"
 	},
+	"require-dev": {
+		"phpunit/phpunit": "^10.5"
+	},
 	"autoload": {
 		"psr-4": {
 			"FriendsOfTYPO3\\Crowdin\\": "Classes/"
+		}
+	},
+	"autoload-dev": {
+		"psr-4": {
+			"FriendsOfTYPO3\\Crowdin\\Tests\\": "Tests/"
 		}
 	},
 	"extra": {
@@ -49,7 +57,10 @@
 			"typo3/cms-composer-installers": true,
 			"typo3/class-alias-loader": true
 		},
-		"bin-dir": ".Build/bin",
-		"vendor-dir": ".Build/vendor"
+        "bin-dir": ".Build/bin",
+        "vendor-dir": ".Build/vendor"
+    },
+	"scripts": {
+		"ci:tests:unit": "phpunit -c Tests/phpunit.xml.dist"
 	}
 }


### PR DESCRIPTION
Injecting an instance of the Setup class in the commands allows us to add tests for those commands. The tests just check if the right Setup method is called and the output is correct.